### PR TITLE
Fix compatibility with Kanboard 1.2.27+

### DIFF
--- a/Controller/TrelloJSON2KanboardController.php
+++ b/Controller/TrelloJSON2KanboardController.php
@@ -57,7 +57,10 @@ class TrelloJSON2KanboardController extends BaseController
                     'name' => $project->name,
                 );
 
-                $max_attachment_size = $this->helper->text->phpTobytes(get_upload_max_size());
+                $max_attachment_size = get_upload_max_size();
+                if (is_string($max_attachment_size)) { // Compatibility with Kanboard <= v1.2.26
+                    $max_attachment_size = $this->helper->text->phpTobytes($max_attachment_size);
+                }
 
                 //creating the project
                 $project_id = $this->createNewProject($values);


### PR DESCRIPTION
Since Kanboard 1.2.27+, `$this->helper->text->phpToBytes()` no longer exists, which causes an "Uncaught Error: Call to undefined method ..." when importing. Instead `get_upload_max_size()` already does the conversion internally, returning the number of bytes as an integer.

Detect this and avoid the call `phpTobytes` for newer Kanboard versions.

Link to the commit that removes `phpToBytes`: https://github.com/kanboard/kanboard/commit/b138a99ce30fe6b2f483d65a885e0a3c6409e731